### PR TITLE
add missing dependency on config.mk

### DIFF
--- a/installer/Makefile
+++ b/installer/Makefile
@@ -60,7 +60,7 @@ $(xpi_file): $(build_dir) $(xpi_built)
 
 include config.mk
 
-$(build_dir)/%: %
+$(build_dir)/%: % config.mk
 	@sed -E \
     -e 's/\$$\(ID\)/$(id)/g' \
     -e 's/\$$\(DOMAINS\)/$(domains)/g' \


### PR DESCRIPTION
Since bootstrap.js or any other file modified by sed command depend on config.mk file, it should be listed as a dependency so the file are recreated when config.mk is updated
