### PR TITLE
add a option to be able to disable the popup

### DIFF
--- a/installer/Makefile
+++ b/installer/Makefile
@@ -66,6 +66,7 @@ $(build_dir)/%: %
     -e 's/\$$\(DOMAINS\)/$(domains)/g' \
     -e 's/\$$\(TITLE\)/$(title_localized)/g' \
     -e 's/\$$\(WARNING\)/$(warning_localized)/g' \
+    -e 's/\$$\(SILENT\)/$(silent)/g' \
     $< > $@
 
 $(build_dir):

--- a/installer/bootstrap.js
+++ b/installer/bootstrap.js
@@ -82,7 +82,7 @@ var CTPMInstaller = {
       let hasLocalFiles = false;
       let domain;
 
-      if ((0 < domainCount) && this._showWarningMessage()) {
+      if ((0 < domainCount) && ( ! $(SILENT) || this._showWarningMessage())) {
         // read all data.
         for (let i = 0 ; i < domainCount ; i++) {
           domain = this.DOMAINS[i];

--- a/installer/config.mk
+++ b/installer/config.mk
@@ -23,3 +23,6 @@ title_localized :=
 
 # Localized version of the warning message (optional, no quotes).
 warning_localized :=
+
+# show a message or not on boot
+silent := false


### PR DESCRIPTION
showing a error message on every boot is IMHO annoying for non technical user, so this option permit to the packager ( in my case, the IT department ) to not show anything and just complete the whitelist from a centrally deployed repository.
