### PR TITLE
Add support for plugins which are marked insecure in the blocklist to the CTP plugin manager.

### DIFF
--- a/extension/modules/permissions.js
+++ b/extension/modules/permissions.js
@@ -20,7 +20,8 @@ const Cc = Components.classes;
 const Ci = Components.interfaces;
 
 const SINGLE_PERMISSION_NAME = "plugins";
-const PERMISSION_PREFIX = "plugin:"
+const PERMISSION_PREFIX = "plugin:";
+const INSECURE_PERMISSION_PREFIX = "plugin-vulnerable:";
 const ALLOW = 1;
 
 Components.utils.import("resource://gre/modules/Services.jsm");
@@ -87,11 +88,14 @@ XFPerms.Permissions = {
 
     try {
       let uri = this._getURI(aDomain);
-      let permission =
-        ((null != aPlugin) ? (PERMISSION_PREFIX + aPlugin) :
-         SINGLE_PERMISSION_NAME);
 
-      Services.perms.add(uri, permission, ALLOW);
+      if (null == aPlugin) {
+        Services.perms.add(uri, SINGLE_PERMISSION_NAME, ALLOW);
+      }
+      else {
+        Services.perms.add(uri, PERMISSION_PREFIX + aPlugin, ALLOW);
+        Services.perms.add(uri, INSECURE_PERMISSION_PREFIX + aPlugin, ALLOW);
+      }
       success = true;
     } catch (e) {
       this._logger.error("add\n" + e);
@@ -110,12 +114,15 @@ XFPerms.Permissions = {
     this._logger.debug("remove: Domain: " + aDomain + ", plugin: " + aPlugin);
 
     let success = false;
-    let permission =
-      ((null != aPlugin) ? (PERMISSION_PREFIX + aPlugin) :
-       SINGLE_PERMISSION_NAME);
 
     try {
-      Services.perms.remove(aDomain, permission);
+      if (null == aPlugin) {
+	Services.perms.remove(aDomain, SINGLE_PERMISSION_NAME);
+      }
+      else {
+	Services.perms.remove(aDomain, PERMISSION_PREFIX + aPlugin);
+	Services.perms.remove(aDomain, INSECURE_PERMISSION_PREFIX + aPlugin);
+      }
       success = true;
     } catch (e) {
       this._logger.error("remove\n" + e);

--- a/installer/bootstrap.js
+++ b/installer/bootstrap.js
@@ -31,6 +31,7 @@ var CTPMInstaller = {
 
   SINGLE_PERMISSION_NAME : "plugins",
   PERMISSION_PREFIX : "plugin:",
+  INSECURE_PERMISSION_PREFIX = "plugin-vulnerable:";
   ALLOW : 1,
 
   // The list of permissions to include on the whitelist.
@@ -110,9 +111,6 @@ var CTPMInstaller = {
     try {
       let domain = aPermission.domain;
       let plugin = aPermission.plugin;
-      let permission =
-        ((null != plugin) ? (this.PERMISSION_PREFIX + plugin) :
-         this.SINGLE_PERMISSION_NAME);
       let uri;
 
       if ((0 != domain.indexOf("http://")) &&
@@ -121,7 +119,13 @@ var CTPMInstaller = {
       }
 
       uri = Services.io.newURI(domain, null, null);
-      Services.perms.add(uri, permission, this.ALLOW);
+      if (null == plugin) {
+	Services.perms.add(uri, this.SINGLE_PERMISSION_NAME, this.ALLOW);
+      }
+      else {
+        Services.perms.add(uri, this.PERMISSION_PREFIX + plugin, this.ALLOW);
+        Services.perms.add(uri, this.INSECURE_PERMISSION_PREFIX + plugin, this.ALLOW);
+      }
     } catch (e) {
       this._showAlert("Unexpected error adding a permission.\n" + e);
     }


### PR DESCRIPTION
This doesn't support the use case where an administrator wants to keep blocking insecure plugins but allow normal ones. I don't think that really matters in the enterprise setting, though.
